### PR TITLE
[FEATURE] 졸업요건 검사 API

### DIFF
--- a/src/main/java/com/smunity/graduation/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/controller/GraduationController.java
@@ -1,0 +1,22 @@
+package com.smunity.graduation.domain.graduation.controller;
+
+import com.smunity.graduation.domain.graduation.dto.GraduationResponseDto;
+import com.smunity.graduation.domain.graduation.service.GraduationService;
+import com.smunity.graduation.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/graduation")
+@RequiredArgsConstructor
+@RestController
+public class GraduationController {
+
+    GraduationService graduationService;
+
+    @GetMapping("")
+    public ApiResponse<GraduationResponseDto> getGraduationCriteria() {
+        return ApiResponse.onSuccess(graduationService.getGraduationCriteria());
+    }
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/controller/GraduationController.java
@@ -4,10 +4,12 @@ import com.smunity.graduation.domain.graduation.dto.GraduationResponseDto;
 import com.smunity.graduation.domain.graduation.service.GraduationService;
 import com.smunity.graduation.global.common.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RequestMapping("/graduation")
 @RequiredArgsConstructor
 @RestController

--- a/src/main/java/com/smunity/graduation/domain/graduation/controller/GraduationController.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/controller/GraduationController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class GraduationController {
 
-    GraduationService graduationService;
+    private final GraduationService graduationService;
 
     @GetMapping("")
     public ApiResponse<GraduationResponseDto> getGraduationCriteria() {

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
@@ -1,0 +1,25 @@
+package com.smunity.graduation.domain.graduation.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+public record GraduationResponseDto(
+
+    List<SubjectResponseDto> subjects
+
+) {
+    @Builder
+    public record SubjectResponseDto(
+            String name,
+            int total,
+            int count,
+            int major,
+            int culture,
+            int common,
+            int lack
+    ) {
+    }
+
+}
+

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
@@ -2,7 +2,9 @@ package com.smunity.graduation.domain.graduation.dto;
 
 import com.smunity.graduation.domain.accounts.entity.User;
 import com.smunity.graduation.domain.accounts.entity.Year;
+import com.smunity.graduation.domain.graduation.entity.Subject;
 import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
+import com.smunity.graduation.domain.graduation.repository.SubjectRepository;
 import com.smunity.graduation.domain.graduation.temporary.CourseTemporary;
 import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
@@ -14,7 +16,7 @@ import java.util.List;
 @Builder
 public record GraduationResponseDto(
 
-        List<SubjectResponseDto> subjects
+        List<SubjectResponseDto> result
 
 ) {
     /**
@@ -52,7 +54,8 @@ public record GraduationResponseDto(
      * - 일반 교양
      * 영역 구분 없이 자유럽게 선택 이수, 33학점 이상 이수
      */
-    public static GraduationResponseDto to(List<CourseTemporary> courses, Year year, User user) {
+    public static GraduationResponseDto to(List<CourseTemporary> courses, Year year,
+                                           User user, SubjectRepository subjectRepository) {
 
         List<SubjectResponseDto> subjects = new ArrayList<>();
 
@@ -67,13 +70,15 @@ public record GraduationResponseDto(
                 //총 이수 학점
                 .count(count)
                 //전공 = 전공 심화(MAJOR_I) + 전공 선택(MAJOR_S)
-                .major(getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I.getType(), SubjectType.MAJOR_S.getType())))
+                .major(getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I.getType(),
+                        SubjectType.MAJOR_S.getType())))
                 //교양 = 교양 필수(CULTURE_E) + 교양 선택(CULTURE_S)
-                .culture(getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E.getType(), SubjectType.CULTURE_S.getType())))
+                .culture(getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E.getType(),
+                        SubjectType.CULTURE_S.getType())))
                 //일반 = 이수 과목 - 전공 심화(MAJOR_I) - 전공 선택(MAJOR_S) -  교양 필수(CULTURE_E) - 교양 선택(CULTURE_S)
                 .common(getCreditsWithOutSubjectType(courses,
-                        List.of(SubjectType.MAJOR_I, SubjectType.CULTURE_S,
-                                SubjectType.CULTURE_E, SubjectType.CULTURE_S)))
+                        List.of(SubjectType.MAJOR_I.getType(), SubjectType.CULTURE_S.getType(),
+                                SubjectType.CULTURE_E.getType(), SubjectType.CULTURE_S.getType()))) //TODO : 로직 수정 (결과 안맞음)
                 .lack(Math.max(total - count, 0))
                 .build());
 
@@ -95,33 +100,43 @@ public record GraduationResponseDto(
         subjects.add(SubjectResponseDto.to(
                 "culture",
                 year.getCulture(),
-                getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E.getType(), SubjectType.CULTURE_S.getType())))
+                getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E.getType(),
+                        SubjectType.CULTURE_S.getType())))
         );
 
         //CULTURE_B (기초 교양)
+        List<SubjectWithDomainDto> basicCultures = getBasicCultureSubjects(courses, user, subjectRepository);
         subjects.add(SubjectResponseDto.to(
-                "culture_b",
-                year.getCultureCnt(), //TODO : 18,19와 20,21학번 기초교양 기준 확인 -> 모두 4개 로 되어있음
-                getBasicCultureCredits(courses, user))
+                        "culture_b",
+                        year.getCultureCnt(),
+                        basicCultures.size(),
+                        basicCultures
+                )
         );
 
         //CULTURE_E (상명핵심역량교양)
+        List<SubjectWithDomainDto> essentialCultureSubjects
+                = getSangmyungEssentialCultureSubjects(courses, subjectRepository);
         subjects.add(SubjectResponseDto.to(
-                "culture_e",
-                2,
-                getSangmyungEssentialCultureCredits(courses))
+                        "culture_e",
+                        2,
+                        essentialCultureSubjects.size(),
+                        essentialCultureSubjects
+                )
         );
 
         //CULTURE_S (균형 교양) = 5개 영역 중 자신 영역 제외 4개 중 3개
+        List<SubjectWithDomainDto> balanceCultures = getBalanceCultureSubjects(courses, user, subjectRepository);
         subjects.add(SubjectResponseDto.to(
                         "culture_s",
                         3,
-                        getBalanceCultureCredits(courses, user)
+                        balanceCultures.size(),
+                        balanceCultures
                 )
         );
 
         return GraduationResponseDto.builder()
-                .subjects(subjects)
+                .result(subjects)
                 .build();
     }
 
@@ -132,7 +147,7 @@ public record GraduationResponseDto(
                 .sum();
     }
 
-    private static int getCreditsWithOutSubjectType(List<CourseTemporary> courses, List<SubjectType> subjectType) {
+    private static int getCreditsWithOutSubjectType(List<CourseTemporary> courses, List<String> subjectType) {
         return courses.stream()
                 .filter(course -> !subjectType.contains(course.getType()))
                 .mapToInt(CourseTemporary::getCredit)
@@ -140,11 +155,12 @@ public record GraduationResponseDto(
     }
 
     //기초 교양(CULTURE_B) 계산
-    private static int getBasicCultureCredits(List<CourseTemporary> courses, User user) {
+    private static List<SubjectWithDomainDto> getBasicCultureSubjects(List<CourseTemporary> courses,
+                                                                      User user, SubjectRepository subjectRepository) {
 
         //TODO : 장애학생은 EnglishforAcademicPurposes」, 「기초수학」,「컴퓨팅사고와데이터의이해」 및「알고리즘과게임콘텐츠」이수 의무 없음
         //TODO : 외국인 유학생은 「컴퓨팅사고와데이터의이해」, 「알고리즘과게임콘텐츠」이수 의무 없음
-        int result = 0;
+        List<SubjectWithDomainDto> result = new ArrayList<>();
 
         //기초 포함 domain 추출
         List<CourseTemporary> courseWithBasic = courses.stream()
@@ -156,56 +172,57 @@ public record GraduationResponseDto(
         log.info("[ 기초 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithBasic.size());
 
         //사고와 표현
-        long val1 = courseWithBasic.stream()
+        courseWithBasic.stream()
                 .filter(course -> course.getDomain().contains("사고와표현"))
                 .limit(1)
-                .count();
-        log.info("[ 기초 교양 계산 ] 사고와 표현 value : {}", val1);
-        result += val1;
+                .map(course -> {
+                    Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow(); //TODO : 예외처리
+                    return SubjectWithDomainDto.to(subject, "사고와표현");
+                })
+                .forEach(result::add);
 
         //EnglishFoundation or 기초수학
-        long val2 = courseWithBasic.stream()
+        courseWithBasic.stream()
                 .filter(course -> course.getDomain().contains("EnglishFoundation") || // 기초교양 1. EnglishforAcademicPurposes
                         course.getDomain().contains("영어1") || // EnglishFoundation
                         course.getDomain().contains("영어2") || // EnglishFoundation
                         course.getDomain().contains("기초수학") ||
-                        course.getDomain().contains("기초미적분학") // 기초교양 2. 기초수학 개편 전
+                        course.getDomain().contains("기초미적분학") // 기초교양 2. 기초수학 개편 전)
                 )
                 .limit(1)
-                .count();
-        log.info("[ 기초 교양 계산 ] EnglishforAcademicPurposes or 기초수학 value : {}", val2);
-        result += val2;
+                .map(course -> {
+                    Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                    return SubjectWithDomainDto.to(subject, "EnglishforAcademicPurposes 또는 기초수학");
+                })
+                .forEach(result::add);
 
         //컴퓨팅사고 or 알고리즘과게임 : 18, 19학번의 경우 택1, 20학번 부터는 각각 따로 이수 필요
-        long val3 = 0;
         if (user.getUserName().startsWith("2019") || user.getUserName().startsWith("2018")) {
             //18, 19학번 : 컴퓨팅사고와데이터의이해와 알고리즘과게임콘텐츠 택 1
-            val3 += courseWithBasic.stream()
+            courseWithBasic.stream()
                     .filter(course -> course.getDomain().contains("컴퓨팅사고와데이터의이해") ||
                             course.getDomain().contains("컴퓨팅사고와게임디자인") || // 컴퓨팅사고와데이터의이해 개편 전
                             course.getDomain().contains("컴퓨팅사고와문제해결") || // 컴퓨팅사고와데이터의이해 개편 전
-                            course.getDomain().contains("알고리즘과게임콘텐츠"))
-                    .limit(1)
-                    .count();
-            log.info("[ 기초 교양 계산 ] 19학번 - 컴퓨팅 or 알고리즘 value : {}", val3);
-        } else {
-            //그 외 20학번 이상 : 컴퓨팅사고와데이터의이해와 알고리즘과게임콘텐츠 각각 이수
-            val3 += courseWithBasic.stream()
-                    .filter(course -> course.getDomain().contains("컴퓨팅사고와데이터의이해") ||
-                            course.getDomain().contains("컴퓨팅사고와게임디자인") || // 컴퓨팅사고와데이터의이해 개편 전
-                            course.getDomain().contains("컴퓨팅사고와문제해결") // 컴퓨팅사고와데이터의이해 개편 전
+                            course.getDomain().contains("알고리즘과게임콘텐츠")
                     )
                     .limit(1)
-                    .count();
-
-            val3 += courseWithBasic.stream()
+                    .map(course -> {
+                        Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                        return SubjectWithDomainDto.to(subject, "컴퓨팅사고와데이터의이해 또는 알고리즘과게임콘텐츠");
+                    })
+                    .forEach(result::add);
+        } else {
+            //그 외 20학번 이상 : 컴퓨팅사고와데이터의이해와 알고리즘과게임콘텐츠 각각 이수
+            courseWithBasic.stream()
                     .filter(course -> course.getDomain().contains("알고리즘과게임콘텐츠"))
                     .limit(1)
-                    .count();
-            log.info("[ 기초 교양 계산 ] 20학번 이상 - 컴퓨팅 value : {}", val3);
-        }
+                    .map(course -> {
+                        Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                        return SubjectWithDomainDto.to(subject, "알고리즘과게임콘텐츠");
+                    })
+                    .forEach(result::add);
 
-        result += val3;
+        }
 
         //교양과 인성 -> 2023학년도 전기(2024.2.) 졸업예정자 졸업기준 2018~2021학번 교양과 인성 이수 필요 없어짐
 //        long val4 = courseWithBasic.stream()
@@ -227,9 +244,11 @@ public record GraduationResponseDto(
     }
 
     //상명핵심역량교양(CULTURE_E) 계산
-    private static int getSangmyungEssentialCultureCredits(List<CourseTemporary> courses) {
+    private static List<SubjectWithDomainDto> getSangmyungEssentialCultureSubjects(List<CourseTemporary> courses,
+                                                                                   SubjectRepository subjectRepository) {
 
         //TODO : 「상명CareerStart」 2020학년도부터 폐지됨, 미수강 및 재수강의 경우 소급 적용하여 이수 의무 없음
+        List<SubjectWithDomainDto> result = new ArrayList<>();
 
         //핵심 포함 domain 추출
         List<CourseTemporary> courseWithEssential = courses.stream()
@@ -238,22 +257,61 @@ public record GraduationResponseDto(
                 .toList();
         log.info("[ 상명핵심역량 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithEssential.size());
 
-        //창의적문제 or 융복합
-        long val1 = courseWithEssential.stream()
-                .filter(course -> course.getDomain().contains("전문지식탐구역량") ||
-                        course.getDomain().contains("창의적문제해결역량") ||
-                        course.getDomain().contains("융복합역량") ||
-                        course.getDomain().contains("다양성존중역량") ||
-                        course.getDomain().contains("윤리실천역량"))
-                .limit(2)
-                .count();
-        log.info("[ 상명핵심역량 교양 계산 ] 창의적문제 or 융복합 value : {}", val1);
+        courseWithEssential.stream()
+                .filter(course -> course.getDomain().contains("전문지식탐구역량"))
+                .limit(1)
+                .map(course -> {
+                    Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                    return SubjectWithDomainDto.to(subject, "전문지식탐구역량");
+                })
+                .forEach(result::add);
 
-        return (int) val1;
+        courseWithEssential.stream()
+                .filter(course -> course.getDomain().contains("창의적문제해결역량"))
+                .limit(1)
+                .map(course -> {
+                    Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                    return SubjectWithDomainDto.to(subject, "창의적문제해결역량");
+                })
+                .forEach(result::add);
+
+
+        courseWithEssential.stream()
+                .filter(course -> course.getDomain().contains("융복합역량"))
+                .limit(1)
+                .map(course -> {
+                    Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                    return SubjectWithDomainDto.to(subject, "융복합역량");
+                })
+                .forEach(result::add);
+
+        courseWithEssential.stream()
+                .filter(course -> course.getDomain().contains("다양성존중역량"))
+                .limit(1)
+                .map(course -> {
+                    Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                    return SubjectWithDomainDto.to(subject, "다양성존중역량");
+                })
+                .forEach(result::add);
+
+
+        courseWithEssential.stream()
+                .filter(course -> course.getDomain().contains("윤리실천역량"))
+                .limit(1)
+                .map(course -> {
+                    Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                    return SubjectWithDomainDto.to(subject, "윤리실천역량");
+                })
+                .forEach(result::add);
+
+        return result;
     }
 
     //균형 교양(CULTURE_S) 계산
-    private static int getBalanceCultureCredits(List<CourseTemporary> courses, User user) {
+    private static List<SubjectWithDomainDto> getBalanceCultureSubjects(List<CourseTemporary> courses, User user, SubjectRepository subjectRepository) {
+
+        List<SubjectWithDomainDto> result = new ArrayList<>();
+        String userType = user.getProfile().getDepartment().getType();
 
         //균형 포함 domain 추출
         List<CourseTemporary> courseWithBalance = courses.stream()
@@ -263,55 +321,66 @@ public record GraduationResponseDto(
         log.info("[ 균형 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithBalance.size());
 
         //균형(인문)
-        long humanities = courseWithBalance.stream()
-                .filter(course -> course.getDomain().contains("인문"))
-                .limit(1)
-                .count();
-        log.info("[ 균형 교양 계산 ] 인문 value : {}", humanities);
+        if (!userType.equals("인문")) {
+            courseWithBalance.stream()
+                    .filter(course -> course.getDomain().contains("인문"))
+                    .limit(1)
+                    .map(course -> {
+                        Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                        return SubjectWithDomainDto.to(subject, "인문");
+                    })
+                    .forEach(result::add);
+        }
 
         //균형(사회)
-        long society = courseWithBalance.stream()
-                .filter(course -> course.getDomain().contains("사회"))
-                .limit(1)
-                .count();
-        log.info("[ 균형 교양 계산 ] 사회 value : {}", society);
+        if (!userType.equals("사회")) {
+            courseWithBalance.stream()
+                    .filter(course -> course.getDomain().contains("사회"))
+                    .limit(1)
+                    .map(course -> {
+                        Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                        return SubjectWithDomainDto.to(subject, "사회");
+                    })
+                    .forEach(result::add);
+        }
 
         //균형(자연)
-        long nature = courseWithBalance.stream()
-                .filter(course -> course.getDomain().contains("자연"))
-                .limit(1)
-                .count();
-        log.info("[ 균형 교양 계산 ] 자연 value : {}", nature);
+        if (!userType.equals("자연")) {
+            courseWithBalance.stream()
+                    .filter(course -> course.getDomain().contains("자연"))
+                    .limit(1)
+                    .map(course -> {
+                        Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                        return SubjectWithDomainDto.to(subject, "자연");
+                    })
+                    .forEach(result::add);
+        }
 
         //균형(공학)
-        long engineering = courseWithBalance.stream()
-                .filter(course -> course.getDomain().contains("공학"))
-                .limit(1)
-                .count();
-        log.info("[ 균형 교양 계산 ] 공학 value : {}", engineering);
+        if (!userType.equals("공학")) {
+            courseWithBalance.stream()
+                    .filter(course -> course.getDomain().contains("공학"))
+                    .limit(1)
+                    .map(course -> {
+                        Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                        return SubjectWithDomainDto.to(subject, "공학");
+                    })
+                    .forEach(result::add);
+        }
 
         //균형(예술)
-        long art = courseWithBalance.stream()
-                .filter(course -> course.getDomain().contains("예술"))
-                .limit(1)
-                .count();
-        log.info("[ 균형 교양 계산 ] 예술 value : {}", art);
-
-        //TODO : 예외처리
-        String userType = user.getProfile().getDepartment().getType();
-        switch (userType) {
-            case "인문":
-                return (int) (society + nature + engineering + art);
-            case "사회":
-                return (int) (humanities + nature + engineering + art);
-            case "자연":
-                return (int) (humanities + society + engineering + art);
-            case "공학":
-                return (int) (humanities + society + nature + art);
-            case "예술":
-                return (int) (humanities + society + nature + engineering);
+        if (!userType.equals("예술")) {
+            courseWithBalance.stream()
+                    .filter(course -> course.getDomain().contains("예술"))
+                    .limit(1)
+                    .map(course -> {
+                        Subject subject = subjectRepository.findById(course.getSubject().getId()).orElseThrow();
+                        return SubjectWithDomainDto.to(subject, "예술");
+                    })
+                    .forEach(result::add);
         }
-        throw new RuntimeException();
+
+        return result;
     }
 
     private static int getAllCredits(List<CourseTemporary> courses) {

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
@@ -77,7 +77,7 @@ public record GraduationResponseDto(
                         SubjectType.CULTURE_S.getType())))
                 //일반 = 이수 과목 - 전공 심화(MAJOR_I) - 전공 선택(MAJOR_S) -  교양 필수(CULTURE_E) - 교양 선택(CULTURE_S)
                 .common(getCreditsWithOutSubjectType(courses,
-                        List.of(SubjectType.MAJOR_I.getType(), SubjectType.CULTURE_S.getType(),
+                        List.of(SubjectType.MAJOR_I.getType(), SubjectType.MAJOR_S.getType(),
                                 SubjectType.CULTURE_E.getType(), SubjectType.CULTURE_S.getType()))) //TODO : 로직 수정 (결과 안맞음)
                 .lack(Math.max(total - count, 0))
                 .build());

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
@@ -1,24 +1,261 @@
 package com.smunity.graduation.domain.graduation.dto;
 
+import com.smunity.graduation.domain.accounts.entity.Year;
+import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
+import com.smunity.graduation.domain.graduation.temporary.CourseTemporary;
 import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.List;
 
+@Slf4j
+@Builder
 public record GraduationResponseDto(
 
-    List<SubjectResponseDto> subjects
+        List<SubjectResponseDto> subjects
 
 ) {
+    public static GraduationResponseDto from(List<CourseTemporary> courses, Year year) {
+
+        List<SubjectResponseDto> subjects = new ArrayList<>();
+
+        //TODO : 예외처리
+        //TOTAL (전체)
+        subjects.add(SubjectResponseDto.builder()
+                .name("total")
+                //총 기준 학점
+                .total(year.getAll())
+                //총 이수 학점
+                .count(getAllCredits(courses))
+                //전공 = 전공 심화(MAJOR_I) + 전공 선택(MAJOR_S)
+                .major(getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I, SubjectType.MAJOR_S)))
+                //교양 = 교양 필수(CULTURE_E) + 교양 선택(CULTURE_S)
+                .culture(getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E, SubjectType.CULTURE_S)))
+                //일반 = 이수 과목 - 전공 심화(MAJOR_I) - 전공 선택(MAJOR_S) -  교양 필수(CULTURE_E) - 교양 선택(CULTURE_S)
+                .common(getCreditsWithOutSubjectType(courses,
+                        List.of(SubjectType.MAJOR_I, SubjectType.CULTURE_S,
+                                SubjectType.CULTURE_E, SubjectType.CULTURE_S)))
+                .build());
+
+        //MAJOR_I (전공 심화)
+        subjects.add(SubjectResponseDto.to(
+                "major_i",
+                year.getMajorI(),
+                getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I)))
+        );
+
+        //MAJOR_S (전공 선택)
+        subjects.add(SubjectResponseDto.to(
+                "major_s",
+                year.getMajorS(),
+                getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_S)))
+        );
+
+        //CULTURE (교양) = 교양 필수(CULTURE_E) + 교양 선택(CULTURE_S)
+        subjects.add(SubjectResponseDto.to(
+                "culture",
+                year.getCulture(),
+                getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E, SubjectType.CULTURE_S)))
+        );
+
+        //CULTURE_B (기초 교양) =
+        subjects.add(SubjectResponseDto.to(
+                "culture_b",
+                year.getCultureCnt(),
+                getBasicCultureCredits(courses))
+        );
+
+        //CULTURE_E (상명핵심역량교양)
+        subjects.add(SubjectResponseDto.to(
+                "culture_e",
+                2,
+                getSangmyungEssentialCultureCredits(courses))
+        );
+
+        //CULTURE_S (균형 교양) = 5개 영역 중 3개
+        subjects.add(SubjectResponseDto.to(
+                "culture_s",
+                3,
+                getBalanceCultureCredits(courses))
+        );
+
+        return GraduationResponseDto.builder()
+                .subjects(subjects)
+                .build();
+    }
+
+    private static int getCreditsBySubjectType(List<CourseTemporary> courses, List<SubjectType> subjectType) {
+        return courses.stream()
+                .filter(course -> subjectType.contains(course.getType()))
+                .mapToInt(CourseTemporary::getCredit)
+                .sum();
+    }
+
+    private static int getCreditsWithOutSubjectType(List<CourseTemporary> courses, List<SubjectType> subjectType) {
+        return courses.stream()
+                .filter(course -> !subjectType.contains(course.getType()))
+                .mapToInt(CourseTemporary::getCredit)
+                .sum();
+    }
+
+    //기초 교양(CULTURE_B) 계산
+    private static int getBasicCultureCredits(List<CourseTemporary> courses) {
+
+        //기초 포함 domain 추출
+        List<CourseTemporary> courseWithBasic = courses.stream()
+                .filter(course -> course.getDomain().contains("기초"))
+                .toList();
+        log.info("[ 기초 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithBasic.size());
+
+        //사고와 표현
+        long val1 = courseWithBasic.stream()
+                .filter(course -> course.getDomain().contains("사고와표현"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 기초 교양 계산 ] 사고와 표현 value : {}", val1);
+
+        //EnglishFoundation or 기초수학
+        long val2 = courseWithBasic.stream()
+                .filter(course -> course.getDomain().contains("EnglishFoundation") ||
+                        course.getDomain().contains("기초수학"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 기초 교양 계산 ] EngFou or 기초수학 value : {}", val2);
+
+        //컴퓨팅사고 or 알고리즘과게임
+        long val3 = courseWithBasic.stream()
+                .filter(course -> course.getDomain().contains("컴퓨팅사고와데이터의이해") ||
+                        course.getDomain().contains("알고리즘과게임콘텐츠"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 기초 교양 계산 ] 컴퓨팅 or 알고리즘 value : {}", val3);
+
+        //교양과 인성
+        //TODO : 사범대학 재학생은 교양과 인성 대신 「미래교사와인성」(구 「교직윤리와인성」) 교과목으로 대체 인정
+        long val4 = courseWithBasic.stream()
+                .filter(course -> course.getDomain().contains("컴퓨팅사고와데이터의이해"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 기초 교양 계산 ] 교양과 인성 value : {}", val2);
+
+
+        return (int) (val1 + val2 + val3);
+    }
+
+    //상명핵심역량교양(CULTURE_E) 계산
+    private static int getSangmyungEssentialCultureCredits(List<CourseTemporary> courses) {
+
+        //핵심 포함 domain 추출
+        List<CourseTemporary> courseWithEssential = courses.stream()
+                .filter(course -> course.getDomain().contains("핵심"))
+                .toList();
+        log.info("[ 상명핵심역량 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithEssential.size());
+
+        //창의적문제 or 융복합
+        long val1 = courseWithEssential.stream()
+                .filter(course -> course.getDomain().contains("창의적문제해결역량"))
+                .filter(course -> course.getDomain().contains("융복합역량"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 상명핵심역량 교양 계산 ] 창의적문제 or 융복합 value : {}", val1);
+
+        //다양성존중 or 윤리실천
+        long val2 = courseWithEssential.stream()
+                .filter(course -> course.getDomain().contains("다양성존중역량"))
+                .filter(course -> course.getDomain().contains("윤리실천역량"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 상명핵심역량 교양 계산 ] 다양성존중 or 윤리실천 value : {}", val2);
+
+        return (int) (val1 + val2);
+    }
+
+    //균형 교양(CULTURE_S) 계산
+    private static int getBalanceCultureCredits(List<CourseTemporary> courses) {
+
+        //균형 포함 domain 추출
+        List<CourseTemporary> courseWithBalance = courses.stream()
+                .filter(course -> course.getDomain().contains("균형"))
+                .toList();
+        log.info("[ 균형 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithBalance.size());
+
+        //균형(인문)
+        long humanities = courseWithBalance.stream()
+                .filter(course -> course.getDomain().contains("인문"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 균형 교양 계산 ] 인문 value : {}", humanities);
+
+        //균형(사회)
+        long society = courseWithBalance.stream()
+                .filter(course -> course.getDomain().contains("사회"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 균형 교양 계산 ] 사회 value : {}", society);
+
+        //균형(자연)
+        long nature = courseWithBalance.stream()
+                .filter(course -> course.getDomain().contains("자연"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 균형 교양 계산 ] 자연 value : {}", nature);
+
+        //균형(공학)
+        long engineering = courseWithBalance.stream()
+                .filter(course -> course.getDomain().contains("공학"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 균형 교양 계산 ] 공학 value : {}", engineering);
+
+        //균형(예술)
+        long art = courseWithBalance.stream()
+                .filter(course -> course.getDomain().contains("예술"))
+                .limit(1)
+                .count() + 1;
+        log.info("[ 균형 교양 계산 ] 예술 value : {}", art);
+
+        //TODO : 사용자 전공별 이수 영역 확인
+
+
+        return (int) (humanities + society + nature + engineering + art);
+    }
+
+    private static int getAllCredits(List<CourseTemporary> courses) {
+        return courses.stream()
+                .mapToInt(CourseTemporary::getCredit)
+                .sum();
+    }
+
     @Builder
     public record SubjectResponseDto(
             String name,
+            //총 기준 학점
             int total,
+
+            //총 이수 학점
             int count,
+
+            //전공
             int major,
+
+            //교양
             int culture,
+
+            //일반
             int common,
+
+            //필요 학점
             int lack
     ) {
+        public static SubjectResponseDto to(String name, int total, int count) {
+            return SubjectResponseDto.builder()
+                    .name(name)
+                    .total(total)
+                    .count(count)
+                    .lack(total - count)
+                    .build();
+        }
     }
 
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
@@ -1,5 +1,6 @@
 package com.smunity.graduation.domain.graduation.dto;
 
+import com.smunity.graduation.domain.accounts.entity.User;
 import com.smunity.graduation.domain.accounts.entity.Year;
 import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
 import com.smunity.graduation.domain.graduation.temporary.CourseTemporary;
@@ -16,47 +17,50 @@ public record GraduationResponseDto(
         List<SubjectResponseDto> subjects
 
 ) {
-    public static GraduationResponseDto from(List<CourseTemporary> courses, Year year) {
+    public static GraduationResponseDto to(List<CourseTemporary> courses, Year year, User user) {
 
         List<SubjectResponseDto> subjects = new ArrayList<>();
 
         //TODO : 예외처리
         //TOTAL (전체)
+        int total = year.getAll();
+        int count = getAllCredits(courses);
         subjects.add(TotalSubjectResponseDto.builder()
                 .name("total")
                 //총 기준 학점
-                .total(year.getAll())
+                .total(total)
                 //총 이수 학점
-                .count(getAllCredits(courses))
+                .count(count)
                 //전공 = 전공 심화(MAJOR_I) + 전공 선택(MAJOR_S)
-                .major(getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I, SubjectType.MAJOR_S)))
+                .major(getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I.getType(), SubjectType.MAJOR_S.getType())))
                 //교양 = 교양 필수(CULTURE_E) + 교양 선택(CULTURE_S)
-                .culture(getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E, SubjectType.CULTURE_S)))
+                .culture(getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E.getType(), SubjectType.CULTURE_S.getType())))
                 //일반 = 이수 과목 - 전공 심화(MAJOR_I) - 전공 선택(MAJOR_S) -  교양 필수(CULTURE_E) - 교양 선택(CULTURE_S)
                 .common(getCreditsWithOutSubjectType(courses,
                         List.of(SubjectType.MAJOR_I, SubjectType.CULTURE_S,
                                 SubjectType.CULTURE_E, SubjectType.CULTURE_S)))
+                .lack(Math.max(total - count, 0))
                 .build());
 
         //MAJOR_I (전공 심화)
         subjects.add(SubjectResponseDto.to(
                 "major_i",
                 year.getMajorI(),
-                getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I)))
+                getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_I.getType())))
         );
 
         //MAJOR_S (전공 선택)
         subjects.add(SubjectResponseDto.to(
                 "major_s",
                 year.getMajorS(),
-                getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_S)))
+                getCreditsBySubjectType(courses, List.of(SubjectType.MAJOR_S.getType())))
         );
 
         //CULTURE (교양) = 교양 필수(CULTURE_E) + 교양 선택(CULTURE_S)
         subjects.add(SubjectResponseDto.to(
                 "culture",
                 year.getCulture(),
-                getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E, SubjectType.CULTURE_S)))
+                getCreditsBySubjectType(courses, List.of(SubjectType.CULTURE_E.getType(), SubjectType.CULTURE_S.getType())))
         );
 
         //CULTURE_B (기초 교양) =
@@ -73,11 +77,12 @@ public record GraduationResponseDto(
                 getSangmyungEssentialCultureCredits(courses))
         );
 
-        //CULTURE_S (균형 교양) = 5개 영역 중 3개
+        //CULTURE_S (균형 교양) = 5개 영역 중 자신 영역 제외 4개 중 3개
         subjects.add(SubjectResponseDto.to(
-                "culture_s",
-                3,
-                getBalanceCultureCredits(courses))
+                        "culture_s",
+                        3,
+                        getBalanceCultureCredits(courses, user)
+                )
         );
 
         return GraduationResponseDto.builder()
@@ -85,7 +90,7 @@ public record GraduationResponseDto(
                 .build();
     }
 
-    private static int getCreditsBySubjectType(List<CourseTemporary> courses, List<SubjectType> subjectType) {
+    private static int getCreditsBySubjectType(List<CourseTemporary> courses, List<String> subjectType) {
         return courses.stream()
                 .filter(course -> subjectType.contains(course.getType()))
                 .mapToInt(CourseTemporary::getCredit)
@@ -105,7 +110,9 @@ public record GraduationResponseDto(
         //기초 포함 domain 추출
         List<CourseTemporary> courseWithBasic = courses.stream()
                 .filter(course -> course.getDomain() != null &&
-                        course.getDomain().contains("기초"))
+                        (course.getDomain().contains("기초") ||
+                                course.getDomain().contains("컴퓨팅")
+                        ))
                 .toList();
         log.info("[ 기초 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithBasic.size());
 
@@ -113,31 +120,35 @@ public record GraduationResponseDto(
         long val1 = courseWithBasic.stream()
                 .filter(course -> course.getDomain().contains("사고와표현"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 기초 교양 계산 ] 사고와 표현 value : {}", val1);
 
         //EnglishFoundation or 기초수학
         long val2 = courseWithBasic.stream()
                 .filter(course -> course.getDomain().contains("EnglishFoundation") ||
+                        course.getDomain().contains("영어1") || // EnglishFoundation 개편 전
+                        course.getDomain().contains("영어2") || // EnglishFoundation 개편 전
                         course.getDomain().contains("기초수학"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 기초 교양 계산 ] EngFou or 기초수학 value : {}", val2);
 
         //컴퓨팅사고 or 알고리즘과게임
         long val3 = courseWithBasic.stream()
                 .filter(course -> course.getDomain().contains("컴퓨팅사고와데이터의이해") ||
+                        course.getDomain().contains("컴퓨팅사고와게임디자인") || // 컴퓨팅사고와데이터의이해 개편 전
+                        course.getDomain().contains("컴퓨팅사고와문제해결") || // 컴퓨팅사고와데이터의이해 개편 전
                         course.getDomain().contains("알고리즘과게임콘텐츠"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 기초 교양 계산 ] 컴퓨팅 or 알고리즘 value : {}", val3);
 
         //교양과 인성
         //TODO : 사범대학 재학생은 교양과 인성 대신 「미래교사와인성」(구 「교직윤리와인성」) 교과목으로 대체 인정
         long val4 = courseWithBasic.stream()
-                .filter(course -> course.getDomain().contains("컴퓨팅사고와데이터의이해"))
+                .filter(course -> course.getDomain().contains("교양과인성"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 기초 교양 계산 ] 교양과 인성 value : {}", val4);
 
 
@@ -156,25 +167,25 @@ public record GraduationResponseDto(
 
         //창의적문제 or 융복합
         long val1 = courseWithEssential.stream()
-                .filter(course -> course.getDomain().contains("창의적문제해결역량"))
-                .filter(course -> course.getDomain().contains("융복합역량"))
+                .filter(course -> course.getDomain().contains("창의적문제해결역량") ||
+                        course.getDomain().contains("융복합역량"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 상명핵심역량 교양 계산 ] 창의적문제 or 융복합 value : {}", val1);
 
         //다양성존중 or 윤리실천
         long val2 = courseWithEssential.stream()
-                .filter(course -> course.getDomain().contains("다양성존중역량"))
-                .filter(course -> course.getDomain().contains("윤리실천역량"))
+                .filter(course -> course.getDomain().contains("다양성존중역량") ||
+                        course.getDomain().contains("윤리실천역량"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 상명핵심역량 교양 계산 ] 다양성존중 or 윤리실천 value : {}", val2);
 
         return (int) (val1 + val2);
     }
 
     //균형 교양(CULTURE_S) 계산
-    private static int getBalanceCultureCredits(List<CourseTemporary> courses) {
+    private static int getBalanceCultureCredits(List<CourseTemporary> courses, User user) {
 
         //균형 포함 domain 추출
         List<CourseTemporary> courseWithBalance = courses.stream()
@@ -187,41 +198,52 @@ public record GraduationResponseDto(
         long humanities = courseWithBalance.stream()
                 .filter(course -> course.getDomain().contains("인문"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 균형 교양 계산 ] 인문 value : {}", humanities);
 
         //균형(사회)
         long society = courseWithBalance.stream()
                 .filter(course -> course.getDomain().contains("사회"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 균형 교양 계산 ] 사회 value : {}", society);
 
         //균형(자연)
         long nature = courseWithBalance.stream()
                 .filter(course -> course.getDomain().contains("자연"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 균형 교양 계산 ] 자연 value : {}", nature);
 
         //균형(공학)
         long engineering = courseWithBalance.stream()
                 .filter(course -> course.getDomain().contains("공학"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 균형 교양 계산 ] 공학 value : {}", engineering);
 
         //균형(예술)
         long art = courseWithBalance.stream()
                 .filter(course -> course.getDomain().contains("예술"))
                 .limit(1)
-                .count() + 1;
+                .count();
         log.info("[ 균형 교양 계산 ] 예술 value : {}", art);
 
-        //TODO : 사용자 전공별 이수 영역 확인
-
-
-        return (int) (humanities + society + nature + engineering + art);
+        //TODO : 예외처리
+        String userType = user.getProfile().getDepartment().getType();
+        switch (userType) {
+            case "인문":
+                return (int) (society + nature + engineering + art);
+            case "사회":
+                return (int) (humanities + nature + engineering + art);
+            case "자연":
+                return (int) (humanities + society + engineering + art);
+            case "공학":
+                return (int) (humanities + society + nature + art);
+            case "예술":
+                return (int) (humanities + society + nature + engineering);
+        }
+        throw new RuntimeException();
     }
 
     private static int getAllCredits(List<CourseTemporary> courses) {

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java
@@ -22,7 +22,7 @@ public record GraduationResponseDto(
 
         //TODO : 예외처리
         //TOTAL (전체)
-        subjects.add(SubjectResponseDto.builder()
+        subjects.add(TotalSubjectResponseDto.builder()
                 .name("total")
                 //총 기준 학점
                 .total(year.getAll())
@@ -104,7 +104,8 @@ public record GraduationResponseDto(
 
         //기초 포함 domain 추출
         List<CourseTemporary> courseWithBasic = courses.stream()
-                .filter(course -> course.getDomain().contains("기초"))
+                .filter(course -> course.getDomain() != null &&
+                        course.getDomain().contains("기초"))
                 .toList();
         log.info("[ 기초 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithBasic.size());
 
@@ -137,10 +138,10 @@ public record GraduationResponseDto(
                 .filter(course -> course.getDomain().contains("컴퓨팅사고와데이터의이해"))
                 .limit(1)
                 .count() + 1;
-        log.info("[ 기초 교양 계산 ] 교양과 인성 value : {}", val2);
+        log.info("[ 기초 교양 계산 ] 교양과 인성 value : {}", val4);
 
 
-        return (int) (val1 + val2 + val3);
+        return (int) (val1 + val2 + val3 + val4);
     }
 
     //상명핵심역량교양(CULTURE_E) 계산
@@ -148,7 +149,8 @@ public record GraduationResponseDto(
 
         //핵심 포함 domain 추출
         List<CourseTemporary> courseWithEssential = courses.stream()
-                .filter(course -> course.getDomain().contains("핵심"))
+                .filter(course -> course.getDomain() != null &&
+                        course.getDomain().contains("핵심"))
                 .toList();
         log.info("[ 상명핵심역량 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithEssential.size());
 
@@ -176,7 +178,8 @@ public record GraduationResponseDto(
 
         //균형 포함 domain 추출
         List<CourseTemporary> courseWithBalance = courses.stream()
-                .filter(course -> course.getDomain().contains("균형"))
+                .filter(course -> course.getDomain() != null &&
+                        course.getDomain().contains("균형"))
                 .toList();
         log.info("[ 균형 교양 계산 ] domain 기초 포함 과목 수 : {}", courseWithBalance.size());
 
@@ -225,37 +228,6 @@ public record GraduationResponseDto(
         return courses.stream()
                 .mapToInt(CourseTemporary::getCredit)
                 .sum();
-    }
-
-    @Builder
-    public record SubjectResponseDto(
-            String name,
-            //총 기준 학점
-            int total,
-
-            //총 이수 학점
-            int count,
-
-            //전공
-            int major,
-
-            //교양
-            int culture,
-
-            //일반
-            int common,
-
-            //필요 학점
-            int lack
-    ) {
-        public static SubjectResponseDto to(String name, int total, int count) {
-            return SubjectResponseDto.builder()
-                    .name(name)
-                    .total(total)
-                    .count(count)
-                    .lack(total - count)
-                    .build();
-        }
     }
 
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/SubjectResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/SubjectResponseDto.java
@@ -1,0 +1,55 @@
+package com.smunity.graduation.domain.graduation.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@SuperBuilder
+public class SubjectResponseDto {
+    String name;
+
+    //총 기준 학점
+    int total;
+
+    //총 이수 학점
+    int count;
+
+    //전공
+    int major;
+
+    //교양
+    int culture;
+
+    //일반
+    int common;
+
+    //필요 학점
+    int lack;
+
+    List<SubjectWithDomainDto> subjects;
+
+    public static SubjectResponseDto to(String name, int total, int count) {
+        return SubjectResponseDto.builder()
+                .name(name)
+                .total(total)
+                .count(count)
+                .lack(Math.max(total - count, 0))
+                .build();
+    }
+
+    public static SubjectResponseDto to(String name, int total, int count, List<SubjectWithDomainDto> subjects) {
+        return SubjectResponseDto.builder()
+                .name(name)
+                .total(total)
+                .count(count)
+                .lack(Math.max(total - count, 0))
+                .subjects(subjects)
+                .build();
+    }
+
+}
+

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/SubjectWithDomainDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/SubjectWithDomainDto.java
@@ -1,0 +1,23 @@
+package com.smunity.graduation.domain.graduation.dto;
+
+import com.smunity.graduation.domain.graduation.entity.Subject;
+import lombok.Builder;
+
+@Builder
+public record SubjectWithDomainDto(
+
+        String name, //이름
+        String number, //학수번호
+        Integer credit, //학점
+        String domain //구분
+
+) {
+    public static SubjectWithDomainDto to(Subject subject, String domain) {
+        return SubjectWithDomainDto.builder()
+                .name(subject.getName())
+                .number(subject.getNumber())
+                .credit(subject.getCredit())
+                .domain(domain)
+                .build();
+    }
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/dto/TotalSubjectResponseDto.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/dto/TotalSubjectResponseDto.java
@@ -1,0 +1,28 @@
+package com.smunity.graduation.domain.graduation.dto;
+
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class TotalSubjectResponseDto extends SubjectResponseDto {
+
+    String name;
+
+    //총 기준 학점
+    int total;
+
+    //총 이수 학점
+    int count;
+
+    //전공
+    int major;
+
+    //교양
+    int culture;
+
+    //일반
+    int common;
+
+}
+

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Culture.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Culture.java
@@ -1,0 +1,35 @@
+package com.smunity.graduation.domain.graduation.entity;
+
+import com.smunity.graduation.domain.graduation.entity.type.CultureSubType;
+import com.smunity.graduation.domain.graduation.entity.type.CultureType;
+import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "graduations_culture")
+@Entity //교양 엔티티
+public class Culture {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "type" ,nullable = false)
+    private SubjectType type;
+
+    @Column(name = "domain" ,nullable = false)
+    private CultureType cultureType;
+
+    @Column(name = "subdomain" ,nullable = false)
+    private CultureSubType cultureSubType;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Culture.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Culture.java
@@ -18,15 +18,19 @@ public class Culture {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
-    @Column(name = "type" ,nullable = false)
+    //이수구분
+    @Column(name = "type", nullable = false)
     private SubjectType type;
 
-    @Column(name = "domain" ,nullable = false)
+    //영역명
+    @Column(name = "domain", nullable = false)
     private CultureType cultureType;
 
-    @Column(name = "subdomain" ,nullable = false)
+    //세부영역명
+    @Column(name = "subdomain", nullable = false)
     private CultureSubType cultureSubType;
 
+    //과목
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subject_id", nullable = false)
     private Subject subject;

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Culture.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Culture.java
@@ -11,22 +11,25 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "graduations_culture")
-@Entity //교양 엔티티
+@Entity
 public class Culture {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //이수구분
+    @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private SubjectType type;
 
     //영역명
+    @Enumerated(EnumType.STRING)
     @Column(name = "domain", nullable = false)
     private CultureType cultureType;
 
     //세부영역명
+    @Enumerated(EnumType.STRING)
     @Column(name = "subdomain", nullable = false)
     private CultureSubType cultureSubType;
 

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Major.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Major.java
@@ -2,8 +2,8 @@ package com.smunity.graduation.domain.graduation.entity;
 
 import com.smunity.graduation.domain.accounts.entity.Department;
 import com.smunity.graduation.domain.graduation.entity.type.Grade;
-import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
 import com.smunity.graduation.domain.graduation.entity.type.Semester;
+import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -19,22 +19,27 @@ public class Major {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    //학년
     @Enumerated(EnumType.STRING)
     @Column(name = "grade", nullable = false)
     private Grade grade;
 
+    //학기
     @Enumerated(EnumType.STRING)
     @Column(name = "semester", nullable = false)
     private Semester semester;
 
+    //이수구분
     @Enumerated(EnumType.STRING)
     @Column(name = "type", nullable = false)
     private SubjectType type;
 
+    //학과
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "department_id", nullable = false)
     private Department department;
 
+    //과목
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subject_id", nullable = false)
     private Subject subject;

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Major.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Major.java
@@ -16,7 +16,7 @@ import lombok.*;
 public class Major {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //학년

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Major.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Major.java
@@ -1,0 +1,43 @@
+package com.smunity.graduation.domain.graduation.entity;
+
+import com.smunity.graduation.domain.accounts.entity.Department;
+import com.smunity.graduation.domain.graduation.entity.type.Grade;
+import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
+import com.smunity.graduation.domain.graduation.entity.type.Semester;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "graduations_major")
+@Entity
+public class Major {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "grade", nullable = false)
+    private Grade grade;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "semester", nullable = false)
+    private Semester semester;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false)
+    private SubjectType type;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "department_id", nullable = false)
+    private Department department;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
@@ -1,6 +1,5 @@
 package com.smunity.graduation.domain.graduation.entity;
 
-import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -33,9 +32,9 @@ public class Subject {
     private String dept;
 
     //이수구분
-    @Enumerated(EnumType.STRING)
+//    @Enumerated(EnumType.STRING)
     @JoinColumn(name = "type", nullable = false)
-    private SubjectType type;
+    private String type;
 
 
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
@@ -1,0 +1,35 @@
+package com.smunity.graduation.domain.graduation.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "graduations_major")
+@Entity
+public class Subject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "number", nullable = false)
+    private String number;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "credit", nullable = false)
+    private Integer credit;
+
+    @Column(name = "dept", nullable = false)
+    private String dept;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
@@ -15,18 +15,23 @@ public class Subject {
     @GeneratedValue(strategy = GenerationType.AUTO)
     private Long id;
 
+    //학수 번호
     @Column(name = "number", nullable = false)
     private String number;
 
+    //이름
     @Column(name = "name", nullable = false)
     private String name;
 
+    //학점
     @Column(name = "credit", nullable = false)
     private Integer credit;
 
+    //개설학부
     @Column(name = "dept", nullable = false)
     private String dept;
 
+    //이수구분
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "subject_id", nullable = false)
     private Subject subject;

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/Subject.java
@@ -1,5 +1,6 @@
 package com.smunity.graduation.domain.graduation.entity;
 
+import com.smunity.graduation.domain.graduation.entity.type.SubjectType;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -7,12 +8,12 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-@Table(name = "graduations_major")
+@Table(name = "graduations_subject")
 @Entity
 public class Subject {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     //학수 번호
@@ -32,9 +33,9 @@ public class Subject {
     private String dept;
 
     //이수구분
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "subject_id", nullable = false)
-    private Subject subject;
+    @Enumerated(EnumType.STRING)
+    @JoinColumn(name = "type", nullable = false)
+    private SubjectType type;
 
 
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/type/CultureSubType.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/type/CultureSubType.java
@@ -1,0 +1,30 @@
+package com.smunity.graduation.domain.graduation.entity.type;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CultureSubType {
+
+    EXPERTISE("전문지식탐구역량"),
+    CREATIVE("창의적문제해결역량"),
+    CONVERGENCE("융복합역량"),
+    DIVERSITY("다양성존중역량"),
+    ETHICS("윤리실천역량"),
+    HUMANITIES("인문"),
+    SOCIETY("사회"),
+    NATURE("자연"),
+    ENGINEERING("공학"),
+    ART("예술"),
+    ;
+
+    private final String type;
+
+    @JsonValue
+    public String getType() {
+        return this.type;
+    }
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/type/CultureType.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/type/CultureType.java
@@ -1,0 +1,24 @@
+package com.smunity.graduation.domain.graduation.entity.type;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CultureType {
+
+    CULTURE("교양"),
+    CULTURE_B("기초"),
+    CULTURE_E("핵심"),
+    CULTURE_S("균형"),
+    ;
+
+    private final String type;
+
+    @JsonValue
+    public String getType() {
+        return this.type;
+    }
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/type/Grade.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/type/Grade.java
@@ -1,0 +1,25 @@
+package com.smunity.graduation.domain.graduation.entity.type;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Grade {
+
+    ALL(0, "전체학년"),
+    FRESHMAN(1, "1학년"),
+    SOPHOMORE(2, "2학년"),
+    JUNIOR(3, "3학년"),
+    SENIOR(4, "4학년");
+
+    private final Integer value;
+    private final String grade;
+
+    @JsonValue
+    public String getGrade() {
+        return this.grade;
+    }
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/type/Semester.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/type/Semester.java
@@ -1,0 +1,24 @@
+package com.smunity.graduation.domain.graduation.entity.type;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Semester {
+
+    FIRST(1, "1학기"),
+    SECOND(2, "2학기"),
+    SUMMER(3, "하계"),
+    WINTER(4, "동계");
+
+    private final Integer value;
+    private final String semester;
+
+    @JsonValue
+    public String getSemester() {
+        return this.semester;
+    }
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/type/Semester.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/type/Semester.java
@@ -8,12 +8,12 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum Semester {
 
-    FIRST(1, "1학기"),
-    SECOND(2, "2학기"),
-    SUMMER(3, "하계"),
-    WINTER(4, "동계");
+    FIRST("1학기"),
+    SECOND("2학기"),
+    SUMMER("하계"),
+    WINTER("동계");
 
-    private final Integer value;
+
     private final String semester;
 
     @JsonValue

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/type/SubjectType.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/type/SubjectType.java
@@ -1,0 +1,23 @@
+package com.smunity.graduation.domain.graduation.entity.type;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SubjectType {
+
+    EDUCATION( "1교직"),
+    MAJOR_S("1전선"),
+    MAJOR_I("1전심"),
+    ;
+
+    private final String type;
+
+    @JsonValue
+    public String getType() {
+        return this.type;
+    }
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/entity/type/SubjectType.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/entity/type/SubjectType.java
@@ -8,9 +8,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum SubjectType {
 
-    EDUCATION( "1교직"),
+    EDUCATION("1교직"),
     MAJOR_S("1전선"),
     MAJOR_I("1전심"),
+    CULTURE_E("교필"),
+    CULTURE_S("교선"),
     ;
 
     private final String type;

--- a/src/main/java/com/smunity/graduation/domain/graduation/repository/CourseTemporaryRepository.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/repository/CourseTemporaryRepository.java
@@ -1,0 +1,11 @@
+package com.smunity.graduation.domain.graduation.repository;
+
+import com.smunity.graduation.domain.graduation.temporary.CourseTemporary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CourseTemporaryRepository extends JpaRepository<CourseTemporary, Long> {
+
+    List<CourseTemporary> findAllByUser_Id(Long id);
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/repository/SubjectRepository.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/repository/SubjectRepository.java
@@ -1,0 +1,8 @@
+package com.smunity.graduation.domain.graduation.repository;
+
+import com.smunity.graduation.domain.graduation.entity.Subject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SubjectRepository extends JpaRepository<Subject, Long> {
+
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
@@ -1,0 +1,37 @@
+package com.smunity.graduation.domain.graduation.service;
+
+import com.smunity.graduation.domain.accounts.entity.User;
+import com.smunity.graduation.domain.accounts.entity.Year;
+import com.smunity.graduation.domain.accounts.repository.YearJpaRepository;
+import com.smunity.graduation.domain.accounts.repository.user.UserRepository;
+import com.smunity.graduation.domain.graduation.dto.GraduationResponseDto;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+public class GraduationService {
+
+    //-------------------임시 레포지토리
+    UserRepository userRepository;
+    YearJpaRepository yearJpaRepository;
+    //-------------------임시 레포지토리
+
+
+    public GraduationResponseDto getGraduationCriteria() {
+        //TODO : 유저 가져오기 -> SecurityContextHolder 필요
+        User user = userRepository.findByUserName("201910926").orElseThrow();
+
+        //TODO : 학번별 졸업 요건 가져오기 -> MS Controller 필요
+        Year year = yearJpaRepository.findByYear(user.getUserName().substring(0, 4)).orElseThrow();
+
+        // [year] major_i : 전공 심화, major_s : 전공 선택, culture : 교양, culture_cnt : ?? , all_score : 필요 이수 학점
+
+        return calculateCriteria();
+    }
+
+    private GraduationResponseDto calculateCriteria() {
+        //TODO : 사용자 들은 과목 조회 -> Course Entity, Repository 필요
+        return null;
+    }
+}

--- a/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
@@ -6,8 +6,11 @@ import com.smunity.graduation.domain.accounts.repository.YearJpaRepository;
 import com.smunity.graduation.domain.accounts.repository.user.UserRepository;
 import com.smunity.graduation.domain.graduation.dto.GraduationResponseDto;
 import com.smunity.graduation.domain.graduation.repository.CourseTemporaryRepository;
+import com.smunity.graduation.domain.graduation.temporary.CourseTemporary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Transactional(readOnly = true)
 @Service
@@ -33,7 +36,7 @@ public class GraduationService {
 
     private GraduationResponseDto calculateCriteria(User user, Year year) {
         //TODO : 사용자 들은 과목 조회 -> Course Entity, Repository 필요
-
-        return null;
+        List<CourseTemporary> courses = courseTemporaryRepository.findAllById(user.getId());
+        return GraduationResponseDto.from(courses, year);
     }
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
@@ -7,25 +7,30 @@ import com.smunity.graduation.domain.accounts.repository.user.UserRepository;
 import com.smunity.graduation.domain.graduation.dto.GraduationResponseDto;
 import com.smunity.graduation.domain.graduation.repository.CourseTemporaryRepository;
 import com.smunity.graduation.domain.graduation.temporary.CourseTemporary;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 @Service
 public class GraduationService {
 
     //-------------------임시 레포지토리
-    UserRepository userRepository;
-    YearJpaRepository yearJpaRepository;
-    CourseTemporaryRepository courseTemporaryRepository;
+    private final UserRepository userRepository;
+    private final YearJpaRepository yearJpaRepository;
+    private final CourseTemporaryRepository courseTemporaryRepository;
     //-------------------임시 레포지토리
 
 
     public GraduationResponseDto getGraduationCriteria() {
         //TODO : 유저 가져오기 -> SecurityContextHolder 필요
         User user = userRepository.findByUserName("201910926").orElseThrow();
+        log.info("[ Graduation Service ] user name : {}", user.getUserName());
 
         //TODO : 학번별 졸업 요건 가져오기 -> MS Controller 필요
         // [year] major_i : 전공 심화, major_s : 전공 선택, culture : 교양, culture_cnt : ?? , all_score : 필요 이수 학점
@@ -35,8 +40,9 @@ public class GraduationService {
     }
 
     private GraduationResponseDto calculateCriteria(User user, Year year) {
+
         //TODO : 사용자 들은 과목 조회 -> Course Entity, Repository 필요
-        List<CourseTemporary> courses = courseTemporaryRepository.findAllById(user.getId());
+        List<CourseTemporary> courses = courseTemporaryRepository.findAllByUser_Id(user.getId());
         return GraduationResponseDto.from(courses, year);
     }
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
@@ -6,6 +6,7 @@ import com.smunity.graduation.domain.accounts.repository.YearJpaRepository;
 import com.smunity.graduation.domain.accounts.repository.user.UserRepository;
 import com.smunity.graduation.domain.graduation.dto.GraduationResponseDto;
 import com.smunity.graduation.domain.graduation.repository.CourseTemporaryRepository;
+import com.smunity.graduation.domain.graduation.repository.SubjectRepository;
 import com.smunity.graduation.domain.graduation.temporary.CourseTemporary;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,8 @@ public class GraduationService {
     private final CourseTemporaryRepository courseTemporaryRepository;
     //-------------------임시 레포지토리
 
+    private final SubjectRepository subjectRepository;
+
 
     public GraduationResponseDto getGraduationCriteria() {
         //TODO : 유저 가져오기 -> SecurityContextHolder 필요
@@ -43,6 +46,6 @@ public class GraduationService {
 
         //TODO : 사용자 들은 과목 조회 -> Course Entity, Repository 필요
         List<CourseTemporary> courses = courseTemporaryRepository.findAllByUser_Id(user.getId());
-        return GraduationResponseDto.to(courses, year, user);
+        return GraduationResponseDto.to(courses, year, user, subjectRepository);
     }
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
@@ -5,6 +5,7 @@ import com.smunity.graduation.domain.accounts.entity.Year;
 import com.smunity.graduation.domain.accounts.repository.YearJpaRepository;
 import com.smunity.graduation.domain.accounts.repository.user.UserRepository;
 import com.smunity.graduation.domain.graduation.dto.GraduationResponseDto;
+import com.smunity.graduation.domain.graduation.repository.CourseTemporaryRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +16,7 @@ public class GraduationService {
     //-------------------임시 레포지토리
     UserRepository userRepository;
     YearJpaRepository yearJpaRepository;
+    CourseTemporaryRepository courseTemporaryRepository;
     //-------------------임시 레포지토리
 
 
@@ -23,15 +25,15 @@ public class GraduationService {
         User user = userRepository.findByUserName("201910926").orElseThrow();
 
         //TODO : 학번별 졸업 요건 가져오기 -> MS Controller 필요
+        // [year] major_i : 전공 심화, major_s : 전공 선택, culture : 교양, culture_cnt : ?? , all_score : 필요 이수 학점
         Year year = yearJpaRepository.findByYear(user.getUserName().substring(0, 4)).orElseThrow();
 
-        // [year] major_i : 전공 심화, major_s : 전공 선택, culture : 교양, culture_cnt : ?? , all_score : 필요 이수 학점
-
-        return calculateCriteria();
+        return calculateCriteria(user, year);
     }
 
-    private GraduationResponseDto calculateCriteria() {
+    private GraduationResponseDto calculateCriteria(User user, Year year) {
         //TODO : 사용자 들은 과목 조회 -> Course Entity, Repository 필요
+
         return null;
     }
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/service/GraduationService.java
@@ -43,6 +43,6 @@ public class GraduationService {
 
         //TODO : 사용자 들은 과목 조회 -> Course Entity, Repository 필요
         List<CourseTemporary> courses = courseTemporaryRepository.findAllByUser_Id(user.getId());
-        return GraduationResponseDto.from(courses, year);
+        return GraduationResponseDto.to(courses, year, user);
     }
 }

--- a/src/main/java/com/smunity/graduation/domain/graduation/temporary/CourseTemporary.java
+++ b/src/main/java/com/smunity/graduation/domain/graduation/temporary/CourseTemporary.java
@@ -1,0 +1,42 @@
+package com.smunity.graduation.domain.graduation.temporary;
+
+//import com.smunity.graduation.domain.graduation.entity.Subject;
+
+import com.smunity.graduation.domain.accounts.entity.User;
+import com.smunity.graduation.domain.graduation.entity.Subject;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "core_course")
+public class CourseTemporary {
+
+    @Id
+    private Long id;
+
+    @Column
+    private Integer year;
+
+    @Column
+    private String semester;
+
+    @Column
+    private Integer credit;
+
+    //    @Enumerated(EnumType.STRING)
+    @Column(name = "type")
+    private String type;
+
+    @Column
+    private String domain;
+
+    //과목
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subject_id", nullable = false)
+    private Subject subject;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+}

--- a/src/main/java/com/smunity/graduation/global/config/SecurityConfig.java
+++ b/src/main/java/com/smunity/graduation/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 public class SecurityConfig {
 
     private final String[] swaggerUrls = {"/swagger-ui/**", "/v3/**"};
-    private final String[] authUrls = {"/", "/api/v1/accounts/**", "graduation/**"};
+    private final String[] authUrls = {"/", "/api/v1/accounts/**"};
     private final String[] allowedUrls = Stream.concat(Arrays.stream(swaggerUrls), Arrays.stream(authUrls))
             .toArray(String[]::new);
 

--- a/src/main/java/com/smunity/graduation/global/config/SecurityConfig.java
+++ b/src/main/java/com/smunity/graduation/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ import java.util.stream.Stream;
 public class SecurityConfig {
 
     private final String[] swaggerUrls = {"/swagger-ui/**", "/v3/**"};
-    private final String[] authUrls = {"/", "/api/v1/accounts/**"};
+    private final String[] authUrls = {"/", "/api/v1/accounts/**", "graduation/**"};
     private final String[] allowedUrls = Stream.concat(Arrays.stream(swaggerUrls), Arrays.stream(authUrls))
             .toArray(String[]::new);
 


### PR DESCRIPTION
## 📚 개요
+ #9 

## ✏️ 작업 내용
+ 졸업요건 검사 API

## 💡 주의 사항
+ src/main/java/com/smunity/graduation/domain/graduation/dto/GraduationResponseDto.java 부분이 졸업요건 검사 변형 로직입니다. **_깃허브에서 길이가 긴 변경은 렌더링 하지 않으니 눌러서 봐주시면 되겠습니다._**
+ 로직이 많이 길고 복잡합니다. 조금 더 효율적으로 로직을 수정할 수 있겠지만, 너무 복잡해져서 일단 이렇게 두려고 합니다. 이해가 안 가는 부분은 코멘트 남겨주세요.
+ 현재 기동 중인 스뮤니티 페이지와 검사 결과는 같습니다.(제 데이터 기준입니다) 
+ 필요한 예외처리가 TODO로 되어있지 않거나, 반영되지 않는다면 코멘트 주세요.
+ 장애학생, 외국인 유학생은 아직 검사할 방법이 없어서 TODO로 남겨뒀습니다.

+ SubjectResponseDto와 TotalSubjectResponseDto은 상속을 위해 record가 아닌 class로 작업했습니다.
+ 엔티티 내에 type과같은 Enum처리가 잘 매핑되지 않아 String으로 처리했습니다. 
+ User, Year, Course는 임시로 만들어서 사용했습니다. Merge후 리팩토링 하겠습니다.
+ Response 예시는 Notion 페이지에 있습니다.